### PR TITLE
Remove xv6 from OS-standard-env

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,1 @@
-[submodule "gwu-xv6"]
-	path = gwu-xv6
-	url = https://github.com/gparmer/gwu-xv6.git
+


### PR DESCRIPTION
@gparmer

Assuming you still will be packaging xv6 with homework assignments.  
environment should not bundle the code with it